### PR TITLE
Remove unused imports

### DIFF
--- a/src/Control/Arrow.purs
+++ b/src/Control/Arrow.purs
@@ -5,7 +5,6 @@ module Control.Arrow where
 import Prelude
 
 import Data.Profunctor.Strong
-import Data.Tuple (Tuple(..), swap)
 
 -- | The `Arrow` type class combines the operations of a `Category` with those of
 -- | a `Strong` profunctor.

--- a/src/Control/Arrow/Kleisli.purs
+++ b/src/Control/Arrow/Kleisli.purs
@@ -6,7 +6,7 @@ import Prelude
 
 import Data.Profunctor
 import Data.Profunctor.Strong
-import Data.Tuple (Tuple(..), swap)
+import Data.Tuple (Tuple(..))
 
 import Control.Arrow
 import Control.Plus

--- a/src/Control/Arrow/Static.purs
+++ b/src/Control/Arrow/Static.purs
@@ -7,7 +7,6 @@ import Prelude
 import Data.Profunctor
 import Data.Profunctor.Strong
 import Data.Profunctor.Choice
-import Data.Tuple (Tuple(..))
 
 import Control.Arrow
 


### PR DESCRIPTION
The PureScript compiler warns about unused imports as of 0.7.6.
